### PR TITLE
Fix tauri + vite configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,3 @@ yarn tauri:build
 ```
 yarn lint
 ```
-
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "email": "oss@dbl.works"
   },
   "scripts": {
-    "serve": "vite",
-    "build": "vite build",
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
     "lint": "eslint .",
     "tauri:build": "tauri build",
     "tauri:serve": "vite preview",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "eslint src --ext .js,.vue",
     "tauri:build": "tauri build",
     "tauri:serve": "vite preview",
     "tauri:dev": "tauri dev"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build",
+    "build": "vite build",
     "lint": "eslint .",
     "tauri:build": "tauri build",
     "tauri:serve": "vite preview",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "build": {
-    "beforeBuildCommand": "",
-    "beforeDevCommand": "",
-    "devPath": "../src",
+    "beforeBuildCommand": "yarn build",
+    "beforeDevCommand": "yarn dev",
+    "devPath": "http://localhost:1523",
     "distDir": "../dist"
   },
   "package": {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,11 +1,29 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import { tauri } from 'vite-plugin-tauri';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), tauri()],
+  plugins: [vue()],
   build: {
     outDir: 'dist',
+    // Tauri uses Chromium on Windows and WebKit on macOS and Linux
+    target: process.env.TAURI_PLATFORM == 'windows' ? 'chrome105' : 'safari13',
+    // don't minify for debug builds
+    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
+    // produce sourcemaps for debug builds
+    sourcemap: !!process.env.TAURI_DEBUG,
   },
+  // prevent vite from obscuring rust errors
+  clearScreen: false,
+  // Tauri expects a fixed port, fail if that port is not available
+  server: {
+    port: 1523,
+    strictPort: true,
+    watch: {
+      // 3. tell vite to ignore watching `src-tauri`
+      ignored: ["**/src-tauri/**"],
+    },
+  },
+  // to access the Tauri environment variables set by the CLI with information about the current target
+  envPrefix: ['VITE_', 'TAURI_PLATFORM', 'TAURI_ARCH', 'TAURI_FAMILY', 'TAURI_PLATFORM_VERSION', 'TAURI_PLATFORM_TYPE', 'TAURI_DEBUG'],
 });


### PR DESCRIPTION
Using Vite requires us to change config a bit. We're running vite prior to tauri build now.

Tested locally, both `build` and `dev` commands are working now